### PR TITLE
Add KinFragLib publication (remove preprint)

### DIFF
--- a/.devtools/doi2yaml.py
+++ b/.devtools/doi2yaml.py
@@ -1,0 +1,75 @@
+"""
+Given a DOI, generate a YAML block for data/publications/publications.yaml
+
+Review that the results are accurate before submitting!
+"""
+
+import requests
+import yaml
+from string import ascii_lowercase
+
+_seen_keys = set()
+
+
+def request_doi(doi):
+    r = requests.get(
+        f"http://dx.doi.org/{doi}", headers={"Accept": "application/vnd.citationstyles.csl+json"},
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def citation_to_dict(data):
+    authors = []
+    key = ""
+    for author in data["author"]:
+        if author["sequence"] == "first":
+            key += "".join(author["family"].lower().split())
+        if (author["given"], author["family"]) == ("Andrea", "Volkamer"):
+            authors.append("andrea.volkamer")
+        else:
+            authors.append(f'{author["given"]} {author["family"]}')
+    try:
+        date = data["published-online"]["date-parts"][0]
+    except KeyError:
+        date = data["published-print"]["date-parts"][0]
+    year = date[0]
+
+    ## Create unique key
+    key += str(year)
+    keyprobe = f"{key}"
+    letters = iter(ascii_lowercase)
+    while keyprobe in _seen_keys:
+        keyprobe = f"{key}{next(letters)}"
+    key = keyprobe
+    _seen_keys.add(key)
+
+    return {
+        key: {
+            "key": key,
+            "title": data["title"],
+            "authors": authors,
+            "journal": data["container-title"],
+            "volume": data["volume"],
+            "issue": data["issue"],
+            "pages": data["page"],
+            "year": year,
+            "date": "-".join(map(str, date)),
+            "doi": data["DOI"],
+            "image": "",
+            "pdf": "",
+            "kind": "article",
+        }
+    }
+
+
+if __name__ == "__main__":
+    import sys
+
+    for arg in sys.argv[1:]:
+        try:
+            data = request_doi(arg)
+            print(yaml.dump(citation_to_dict(data)))
+            print()
+        except Exception as e:
+            print(f"# ERROR with doi {arg}: {e}. Payload:", file=sys.stderr)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,4 +35,6 @@ jobs:
             --exclude html5up.net \
             --exclude gepris.dfg.de \
             --exclude "https://github.com/volkamerlab/CADD*" \
-            --exclude "https://github.com/volkamerlab/ratar"
+            --exclude "https://github.com/volkamerlab/ratar" \
+            --exclude "https://dx.doi.org/10.1002/cmdc.201900328" \
+            --exclude "https://dx.doi.org/10.1002/prot.24205"

--- a/content/projects/kinfraglib.md
+++ b/content/projects/kinfraglib.md
@@ -5,7 +5,7 @@ publishdate: 2020-03-03
 weight: 10
 nav: false
 publications:
-- kinfraglib_preprint
+- sydow_2020_kinfraglib
 people:
 - key: paula.schmiel
 - key: dominique.sydow

--- a/data/publications/publications.yaml
+++ b/data/publications/publications.yaml
@@ -25,6 +25,27 @@
 
 #  Books
 
+albanese_2020:
+  key: albanese_2020
+  title: "Is Structure-Based Drug Design Ready for Selectivity Optimization?"
+  authors:
+    - Steven K. Albanese
+    - John D. Chodera
+    - andrea.volkamer
+    - Simon Keng
+    - Robert Abel
+    - Lingle Wang
+  journal: Journal of Chemical Information and Modeling
+  volume:
+  issue:
+  pages:
+  year: 2020
+  date: 2020-10-29
+  doi: "10.1021/acs.jcim.0c00815"
+  image:
+  pdf:
+  kind: article
+
 sydow_2020_kinfraglib:
   key: sydow_2020_kinfraglib
   title: "KinFragLib: Exploring the Kinase Inhibitor Space Using Subpocket-Focused Fragmentation and Recombination"
@@ -131,7 +152,7 @@ bietz_2017_proteinsplus:
   pages: 207 - 214
   year: 2017
   date: 2017-11-01
-  doi: "10.14573/altex.1712031"
+  doi: "10.1016/j.jbiotec.2017.06.004"
   image:
   pdf:
   kind: article
@@ -224,7 +245,7 @@ morger_2020_knowtox:
   authors:
     - andrea-lilian.morger
     - Miriam Mathea
-    - Janosch H.Achenbach
+    - Janosch H. Achenbach
     - Antje Wolf
     - Roland Buesen
     - Klaus-Juergen Schleifer
@@ -384,3 +405,210 @@ kinmap2017:
   image:
   pdf:
   kind: article
+
+subpockets2016:
+  key: subpockets2016
+  title: "Identification and Visualization of Kinase-Specific Subpockets"
+  authors:
+    - andrea.volkamer
+    - Sameh Eid
+    - Samo Turk
+    - Friedrich Rippmann
+    - Simone Fulle
+  journal: Journal of Chemical Information and Modeling
+  volume: 56
+  issue: 2
+  pages: 335-346
+  year: 2016
+  date: 2016-01-06
+  doi: "10.1021/acs.jcim.5b00627"
+  image:
+  pdf:
+  kind: article
+
+
+volkamer2015:
+  authors:
+  - andrea.volkamer
+  - Sameh Eid
+  - Samo Turk
+  - Sabrina Jaeger
+  - Friedrich Rippmann
+  - Simone Fulle
+  date: 2015-1-20
+  doi: 10.1021/ci500624s
+  image: ''
+  issue: '3'
+  journal: Journal of Chemical Information and Modeling
+  key: volkamer2015
+  kind: article
+  pages: 538-549
+  pdf: ''
+  title: 'Pocketome of Human Kinases: Prioritizing the ATP Binding Sites of (Yet) Untapped Protein Kinases for Drug Discovery'
+  volume: '55'
+  year: 2015
+
+
+volkamer2014:
+  authors:
+  - andrea.volkamer
+  - Matthias Rarey
+  date: 2014-3
+  doi: 10.4155/fmc.14.3
+  image: ''
+  issue: '3'
+  journal: Future Medicinal Chemistry
+  key: volkamer2014
+  kind: article
+  pages: 319-331
+  pdf: ''
+  title: Exploiting structural information for drug-target assessment
+  volume: '6'
+  year: 2014
+
+
+wirth2013:
+  authors:
+  - Matthias Wirth
+  - andrea.volkamer
+  - Vincent Zoete
+  - Friedrich Rippmann
+  - Olivier Michielin
+  - Matthias Rarey
+  - Wolfgang H. B. Sauer
+  date: 2013-6-27
+  doi: 10.1007/s10822-013-9659-1
+  image: ''
+  issue: '6'
+  journal: Journal of Computer-Aided Molecular Design
+  key: wirth2013
+  kind: article
+  pages: 511-524
+  pdf: ''
+  title: Protein pocket and ligand shape comparison and its application in virtual screening
+  volume: '27'
+  year: 2013
+
+
+volkamer2012:
+  authors:
+  - andrea.volkamer
+  - Daniel Kuhn
+  - Friedrich Rippmann
+  - Matthias Rarey
+  date: '2012-12-24'
+  doi: 10.1002/prot.24205
+  image: ''
+  issue: '3'
+  journal: 'Proteins: Structure, Function, and Bioinformatics'
+  key: volkamer2012
+  kind: article
+  pages: 479-489
+  pdf: ''
+  title: Predicting enzymatic function from global binding site descriptors
+  volume: '81'
+  year: 2012
+
+
+vonbehren2013:
+  authors:
+  - Mathias M. von Behren
+  - andrea.volkamer
+  - Angela M. Henzler
+  - Karen T. Schomburg
+  - Sascha Urbaczek
+  - Matthias Rarey
+  date: 2013-2-7
+  doi: 10.1021/ci300469h
+  image: ''
+  issue: '2'
+  journal: Journal of Chemical Information and Modeling
+  key: vonbehren2013
+  kind: article
+  pages: 411-422
+  pdf: ''
+  title: Fast Protein Binding Site Comparison via an Index-Based Screening Technology
+  volume: '53'
+  year: 2013
+
+
+ehrlich2012:
+  authors:
+  - Hans-Christian Ehrlich
+  - andrea.volkamer
+  - Matthias Rarey
+  date: '2012-12-12'
+  doi: 10.1021/ci300283a
+  image: ''
+  issue: '12'
+  journal: Journal of Chemical Information and Modeling
+  key: ehrlich2012
+  kind: article
+  pages: 3181-3189
+  pdf: ''
+  title: Searching for Substructures in Fragment Spaces
+  volume: '52'
+  year: 2012
+
+
+dogsitescorer2012:
+  authors:
+  - andrea.volkamer
+  - Daniel Kuhn
+  - Friedrich Rippmann
+  - Matthias Rarey
+  date: 2012-5-23
+  doi: 10.1093/bioinformatics/bts310
+  image: ''
+  issue: '15'
+  journal: Bioinformatics
+  key: dogsitescorer2012
+  kind: article
+  pages: 2074-2075
+  pdf: ''
+  title: 'DoGSiteScorer: a web server for automatic binding site prediction, analysis and druggability assessment'
+  volume: '28'
+  year: 2012
+
+
+volkamer2012b:
+  authors:
+  - andrea.volkamer
+  - Daniel Kuhn
+  - Thomas Grombacher
+  - Friedrich Rippmann
+  - Matthias Rarey
+  date: 2012-1-5
+  doi: 10.1021/ci200454v
+  image: ''
+  issue: '2'
+  journal: Journal of Chemical Information and Modeling
+  key: volkamer2012b
+  kind: article
+  pages: 360-372
+  pdf: ''
+  title: Combining Global and Local Measures for Structure-Based Druggability Predictions
+  volume: '52'
+  year: 2012
+
+
+volkamer2010:
+  authors:
+  - andrea.volkamer
+  - Axel Griewel
+  - Thomas Grombacher
+  - Matthias Rarey
+  date: '2010-10-14'
+  doi: 10.1021/ci100241y
+  image: ''
+  issue: '11'
+  journal: Journal of Chemical Information and Modeling
+  key: volkamer2010
+  kind: article
+  pages: 2041-2052
+  pdf: ''
+  title: 'Analyzing the Topology of Active Sites: On the Prediction of Pockets and Subpockets'
+  volume: '50'
+  year: 2010
+
+

--- a/data/publications/publications.yaml
+++ b/data/publications/publications.yaml
@@ -25,24 +25,24 @@
 
 #  Books
 
-kinfraglib_preprint:
-  key: kinfraglib_preprint
+sydow_2020_kinfraglib:
+  key: sydow_2020_kinfraglib
   title: "KinFragLib: Exploring the Kinase Inhibitor Space Using Subpocket-Focused Fragmentation and Recombination"
   authors:
     - dominique.sydow
     - paula.schmiel
     - jeremie.mortier
     - andrea.volkamer
-  journal: ChemRxiv
+  journal: Journal of Chemical Information and Modeling
   volume:
   issue:
   pages:
   year: 2020
-  date: 2020-07-23
-  doi: "10.26434/chemrxiv.12696392.v1"
+  date: 2020-11-06
+  doi: "10.1021/acs.jcim.0c00839"
   image:
   pdf:
-  kind: preprint
+  kind: article
 
 volkamer_2018_activesites:
   key: volkamer_2018_activesites


### PR DESCRIPTION
## Description

Add KinFragLib publication and remove ChemRxiv preprint.

## TODOs

- [x] Add JCIM publication and remove ChemRxiv preprint from `publications.yaml`
- [x] Update publication label in `kinfraglib.md`
- [x] Check website with `hugo serve` (publication list and KinFragLib project site)

## Status

- [x] Ready to go