### PR TITLE
Update struc2drug events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
              https://github.com/volkamerlab/CADDSeminar_2019,
              https://github.com/volkamerlab/ratar,
              https://dx.doi.org/10.1002/cmdc.201900328,
+             https://onlinelibrary.wiley.com/doi/10.1002/ardp.202100123,
              linkedin.com,
              html5up.net,
              gepris.dfg.de'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,9 @@ jobs:
              https://github.com/volkamerlab/CADDSeminar_2019,
              https://github.com/volkamerlab/ratar,
              https://dx.doi.org/10.1002/cmdc.201900328,
-             https://onlinelibrary.wiley.com/doi/10.1002/ardp.202100123,
+             https://dx.doi.org/10.1002/ardp.202100123,
+             https://www.einsteinfoundation.de/en/people-projects/einstein-bih-visiting-fellows/john-chodera/,
+             https://www.einsteinfoundation.de/en/programmes/einstein-bih-visiting-fellow/,
              linkedin.com,
              html5up.net,
              gepris.dfg.de'

--- a/content/outreach/struc2drug.md
+++ b/content/outreach/struc2drug.md
@@ -61,7 +61,6 @@ More information on Webex {{< external "can be found here" "https://wikis.fu-ber
 
 **From ternary complex formation to target degradation - PROTACs profiling**<br />
 **Ulrike Scheib** (Nuvisan ICB GmbH,  Berlin) & **David Schwefel** (Charité, Berlin)<br />
-
 Ulrike Scheib will talk about biochemical and biophysical assays that are used to follow the key steps of proteolysis targeting chimeras (PROTACs).
 In the second talk, David Schwefel will focus on the structural biology of multi-subunit ubiquitin ligases and targeted protein degradation.
 

--- a/content/outreach/struc2drug.md
+++ b/content/outreach/struc2drug.md
@@ -40,13 +40,12 @@ To get an invite, reach out to us via <a class="icon fa-envelope" href="mailto:s
 
 ### Join us for our upcoming seminars
 
-#### March 11, 2021 · 16:00 (CET)
+We will announce the next seminar shorty.
 
-**From ternary complex formation to target degradation - PROTACs profiling**<br />
-**Ulrike Scheib** (Nuvisan ICB GmbH,  Berlin) & **David Schwefel** (Charité, Berlin)<br />
-
-Ulrike Scheib will talk about biochemical and biophysical assays that are used to follow the key steps of proteolysis targeting chimeras (PROTACs).
-In the second talk, David Schwefel will focus on the structural biology of multi-subunit ubiquitin ligases and targeted protein degradation.
+<!---
+#### June 00, 2021 · 16:00 (CET)
+**TBA**<br />
+**TBA** (TBA,  Berlin) & **TBA** (TBA, Berlin)<br />
 
 The link to the meeting will be the following:<br />
 · {{< external "Click here to open the Webex videocall" "https://fu-berlin.webex.com/fu-berlin/j.php?MTID=m32967b2bfa5c09f6817b0db0c889e1c7" >}}<br />
@@ -54,9 +53,17 @@ The link to the meeting will be the following:<br />
 · Password: `********` (check your email invite!)<br />
 
 More information on Webex {{< external "can be found here" "https://wikis.fu-berlin.de/pages/viewpage.action?pageId=1037667239" >}}.
-
+--->
 
 ### Check out our previous seminars
+
+#### March 11, 2021 (online)
+
+**From ternary complex formation to target degradation - PROTACs profiling**<br />
+**Ulrike Scheib** (Nuvisan ICB GmbH,  Berlin) & **David Schwefel** (Charité, Berlin)<br />
+
+Ulrike Scheib will talk about biochemical and biophysical assays that are used to follow the key steps of proteolysis targeting chimeras (PROTACs).
+In the second talk, David Schwefel will focus on the structural biology of multi-subunit ubiquitin ligases and targeted protein degradation.
 
 #### January 14, 2021 (online)
 

--- a/content/projects/deeplearning-vs.md
+++ b/content/projects/deeplearning-vs.md
@@ -9,7 +9,7 @@ people:
 - key: andrea.volkamer
 funding:
 - name: China Scholarship Council, CSC
-  link: https://www.csc.edu.cn/
+  link: http://www.hongmojing.com/csc/
   more: China State-Sponsored Postgraduate Study Abroad Program
 ---
 


### PR DESCRIPTION
## Description
Update struc2drug events (no seminar in May; next in June or July).

## TODOs
- [x] Move March seminar to "previous"
- [x] Add TBA to "upcoming"
- [x] Fix broken links; add links to linkinator that do work but have 403 or 0 errors (raise issue to remember those exceptions in case we want to deal with them differently)

## Status
- [x] Ready to go