### PR TITLE
Remove DOI for TOC-chapter (broken via doi.org)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
              https://github.com/volkamerlab/ratar,
              https://dx.doi.org/10.1002/cmdc.201900328,
              https://dx.doi.org/10.1002/ardp.202100123,
-             https://dx.doi.org/10.1021/bk-2021-1387.ch010,
              https://dx.doi.org/10.1007/s10822-020-00310-4,
              https://www.einsteinfoundation.de/en/people-projects/einstein-bih-visiting-fellows/john-chodera/,
              https://www.einsteinfoundation.de/en/programmes/einstein-bih-visiting-fellow/,

--- a/data/publications/publications.yaml
+++ b/data/publications/publications.yaml
@@ -38,7 +38,7 @@ sydow_acs_2021:
   pages:
   year: 2021
   date: 2021-07-27
-  doi: "10.1021/bk-2021-1387.ch010"
+  doi:
   image:
   pdf:
   kind: book


### PR DESCRIPTION
DOI for TOC-chapter is correct but cannot be resolved via doi.org; for now let's remove the DOI from the publications.