### PR TITLE
Remove Dominique's Charité email address

### DIFF
--- a/data/team/members.yaml
+++ b/data/team/members.yaml
@@ -121,9 +121,6 @@
   image: /images/team/dominiquesydow.jpg
   project: Binding site comparison for off-target and polypharmacology prediction
   links:
-    - icon: envelope
-      text: dominique.sydow@charite.de
-      url: mailto:dominique.sydow@charite.de
     - icon: linkedin
       text: Linkedin
       url: https://www.linkedin.com/in/dominiquesydow/


### PR DESCRIPTION
Since I won't have access to my email as of 2022, remove the address from the group website.