### PR TITLE
rename NextAID -> NEDD globally

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -21,7 +21,7 @@ On the other hand, we study ligand-based methods, including [machine learning me
 
 Additionally, we continuously work on the integration of the two research areas of structure- and ligand-centered projects, i.e., focusing on [structure-informed machine learning approaches](/projects/kinoml/) applied primarily to [kinases](/research/openkinome/). In this attempt, we are integrating the physical aspects into molecular modelling (e.g. molecular dynamics simulations and free energy calculations) to better sample the drug target interactions. The [OpenKinome](/research/openkinome/) initiative is an ongoing collaboration with the <a href="http://www.choderalab.org/" target="_blank" class="external">lab of Prof. John Chodera</a>, our <a href="https://www.einsteinfoundation.de/en/fellows-projects/einstein-fellows-professors/einstein-bih-visiting-fellows/john-chodera" target="_blank" class="external">Einstein BIH Visiting Fellow</a>.
     
-We are also working together on campus to advance the field of rational drug discovery through the development of neuro-explicit AI models, find out more about NextAID [here]( https://nextaid.cs.uni-saarland.de/). 
+We are also working together on campus to advance the field of rational drug discovery through the development of neuro-explicit AI models, find out more about NEDD [here](https://nedd.cs.uni-saarland.de/). 
 
 <ul class="actions">
     <li><a href="/research" class="button big icon fa-flask">Learn more about our research</a></li>

--- a/content/blog/michael_member.md
+++ b/content/blog/michael_member.md
@@ -4,6 +4,6 @@ date: 2022-12-01
 author: michael.backenkoehler
 ---
 Michael obtained his PhD under the supervision of [Prof. Dr. Verena Wolf](https://mosi.uni-saarland.de).
-As part of the [NextAID](https://nextaid.cs.uni-saarland.de/) team his work focuses on the development of machine learning models for drug discovery.
+As part of the [NEDD](https://nedd.cs.uni-saarland.de/) team his work focuses on the development of machine learning models for drug discovery.
  
 

--- a/content/blog/paula_new.md
+++ b/content/blog/paula_new.md
@@ -4,6 +4,6 @@ date: 2022-12-01T17:16:22+01:00
 author: paula.kramer
 ---
 
-Paula completed her Bioinformatics bachelor’s and master’s at Saarland University. She is joining Volkamer lab as a PhD candidate as part of the [NextAID](https://nextaid.cs.uni-saarland.de/) research group, where the focus is on deep learning for drug discovery. She will be working on combining deep learning with fragment based drug design to generate novel ligand candidates for kinase inhibition.
+Paula completed her Bioinformatics bachelor’s and master’s at Saarland University. She is joining Volkamer lab as a PhD candidate as part of the [NEDD](https://nedd.cs.uni-saarland.de/) research group, where the focus is on deep learning for drug discovery. She will be working on combining deep learning with fragment based drug design to generate novel ligand candidates for kinase inhibition.
 
 

--- a/content/projects/kinfrag-ml.md
+++ b/content/projects/kinfrag-ml.md
@@ -16,8 +16,8 @@ people:  # take from /data/team/members.yml (`key` entry)
 #   link: http://university.website
 #   more: (Department X this is free text)
 funding:
-- name: NextAID
-  link: https://nextaid.cs.uni-saarland.de/
+- name: NEDD
+  link: https://nedd.cs.uni-saarland.de/
 #   more: free text
 # publications:  # take from (or add to) /data/publications/publications.yml
 # - citation_key

--- a/content/projects/kinodata-3D.md
+++ b/content/projects/kinodata-3D.md
@@ -20,8 +20,8 @@ external_resources:
   link: https://github.com/volkamerlab/kinodata-3D-affinity-prediction
   icon: github
 funding:
-- name: NextAID
-  link: https://nextaid.cs.uni-saarland.de/
+- name: NEDD
+  link: https://nedd.cs.uni-saarland.de/
 ---
 
 Machine learning - and especially deep learning - models require large datasets for training. As such datasets, especially those containing protein-ligand-complex information - are more rare in the drug design landscape, we assess the use of _in silico_ structural docking data for machine learning.

--- a/data/team/members.yaml
+++ b/data/team/members.yaml
@@ -107,7 +107,7 @@
   key: lacour.antoine
   role: PostDoc
   status: member
-  project: DockM8 Development, Virtual Screening for NextAID, and Machine Learning for Drug Discovery
+  project: DockM8 Development, Virtual Screening for NEDD, and Machine Learning for Drug Discovery
   image: /images/team/antoinelacour.jpg
   links:
     - icon: envelope


### PR DESCRIPTION
All appropriate mentions and links to the website are changed to avoid confusion with NextAID3.